### PR TITLE
Use logFileName static buffer directly

### DIFF
--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -1369,10 +1369,6 @@ pimegaDetector::pimegaDetector(
                    "pimegaDetector: Disabling logging\n");
       exit(0);
       EnableLog(pimega, 0);
-    } else {
-      log_file_path = (char *)malloc(sizeof(char) * 50);
-      memset(log_file_path, ' ', 50);
-      GetLogFilePath(pimega, log_file_path);
     }
   }
   error_str = ErrorStringPointer(pimega);
@@ -1832,7 +1828,7 @@ asynStatus pimegaDetector::setDefaults(void) {
   setParameter(PimegaSensorBias,
                GetModuleBiasVoltage(pimega, PIMEGA_THREAD_MAIN));
 
-  setParameter(PimegaLogFile, this->log_file_path);
+  setParameter(PimegaLogFile, pimega->logFileName);
 
   SetAcqParamCameraNumCapture(pimega, 1);
 

--- a/pimegaApp/src/pimegaDetector.h
+++ b/pimegaApp/src/pimegaDetector.h
@@ -445,7 +445,6 @@ class pimegaDetector : public ADDriver {
   epicsEventId stopCaptureEventId_;
 
   pimega_t *pimega;
-  char *log_file_path;
   int maxSizeX;
   int maxSizeY;
   int numModulesX_;


### PR DESCRIPTION
Conditionally allocating memory for log_file_path leads to a bug when logging is disabled because pimegaDetector::setDefaults() will later attempt to set the PimegaLogFile parameter based on this uninitialized member. Considering that this was introduced by the fixed commit which aims at hiding the struct fields, and that such hinding no longer makes sense, simply revert to the original approach of using logFileName directly.

Fixes: 0d94f9e (Removed direct pimega pointer calls, 2024-02-23)

---

Fixes #6 