### PR TITLE
Fix stack corruption in dacCountScan.

### DIFF
--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -2043,8 +2043,11 @@ asynStatus pimegaDetector::dacCountScan() {
   getParameter(PimegaDacCountScanStart, &start);
   getParameter(PimegaDacCountScanStop, &stop);
   getParameter(PimegaDacCountScanStep, &step);
-  getParameter(PimegaDacCountScanDac, (int *)&dac);
-  getParameter(PimegaModule, (int *)&current_module);
+  int tmp;
+  getParameter(PimegaDacCountScanDac, &tmp);
+  dac = tmp;
+  getParameter(PimegaModule, &tmp);
+  current_module = tmp;
 
   char fullFileName[PIMEGA_MAX_FILENAME_LEN];
   createFileName(sizeof(fullFileName), fullFileName);


### PR DESCRIPTION
While the dac enum is likely to be already the size and alignment of an int, that was definitely not the case for current_module, since it is an uint8_t. That meant the call to getParameter with the "int *" pointer cast, a case of pointer misuse, was causing stack memory corruption, and could also lead to unaligned access.