### PR TITLE
Upgrade pimega library to use 270D support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       args:
         REPONAME: epics/modules/areaDetector/ADPimega
         BUILD_PACKAGES: libczmq-dev libjson-c-dev
-        BUILD_TAR_PACKAGES: http://download.lnls.br/packages/libpimega_2.5.4-3_amd64.tar.gz
+        BUILD_TAR_PACKAGES: http://download.lnls.br/packages/libpimega_2.5.4-4_amd64.tar.gz
         RUNTIME_PACKAGES: libxml2 libtiff5 libglib2.0-0 libjson-c5 libczmq4 libgomp1
-        RUNTIME_TAR_PACKAGES: http://download.lnls.br/packages/libpimega_2.5.4-3_amd64.tar.gz
+        RUNTIME_TAR_PACKAGES: http://download.lnls.br/packages/libpimega_2.5.4-4_amd64.tar.gz
         RUNDIR: /opt/epics/modules/areaDetector/ADPimega/iocs/pimegaIOC/iocBoot/iocPimega


### PR DESCRIPTION
Due to a damaged 540D detector, Sapucaia beamline at Sirius will be using an assembly with only two modules (3 and 4) until the other modules are repaired. Upgrade the pimega library to use its support for 270D in the IOC, and enable the operation in this unusual scenario.