### PR TITLE
Use PixelMode() API for correct counter selection

### DIFF
--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -629,7 +629,7 @@ asynStatus pimegaDetector::writeInt32(asynUser *pasynUser, epicsInt32 value) {
     status |= imgChipID(value);
     strcat(ok_str, "Chip selected");
   } else if (function == PimegaPixelMode) {
-    status |= setOMRValue(OMR_CSM_SPM, value, function);
+    status |= setPixelMode((pimega_pixel_mode_t)value);
     strcat(ok_str, "Pixel mode set");
   } else if (function == PimegaContinuosRW) {
     status |= setOMRValue(OMR_CRW_SRW, value, function);
@@ -1918,6 +1918,28 @@ asynStatus pimegaDetector::setOMRValue(pimega_omr_t omr, int value, int paramete
   }
 
   setParameter(parameter, value);
+  return asynSuccess;
+}
+
+asynStatus pimegaDetector::setPixelMode(pimega_pixel_mode_t mode) {
+  int all_modules;
+
+  getParameter(PimegaAllModules, &all_modules);
+  int rc = PixelMode(pimega, mode, (pimega_send_to_all_t)all_modules);
+  if (rc != PIMEGA_SUCCESS) {
+    error("Unable to set pixel mode: %s\n", pimega_error_string(rc));
+    return asynError;
+  }
+
+  setParameter(PimegaPixelMode, (int)mode);
+
+  rc = get_read_counter(pimega);
+  if (rc != PIMEGA_SUCCESS) {
+    error("Unable to update read counter: %s\n", pimega_error_string(rc));
+    return asynError;
+  }
+
+  setParameter(PimegaReadCounter, (int)pimega->pimegaParam.read_counter);
   return asynSuccess;
 }
 

--- a/pimegaApp/src/pimegaDetector.h
+++ b/pimegaApp/src/pimegaDetector.h
@@ -468,6 +468,7 @@ class pimegaDetector : public ADDriver {
   asynStatus sensorBias(float voltage);
   asynStatus readCounter(int counter);
   asynStatus senseDacSel(u_int8_t dac);
+  asynStatus setPixelMode(pimega_pixel_mode_t mode);
   // asynStatus imageMode(u_int8_t mode);
   asynStatus sendImage(void);
   asynStatus checkSensors(void);


### PR DESCRIPTION
Removes manual OMR manipulation in favor of the `PixelMode()` API. This ensures the correct counter (Low for SPM, High for CSM) is automatically selected based on the operating mode.