### PR TITLE
Use new acquisition::status field names

### DIFF
--- a/pimegaApp/Db/module.template
+++ b/pimegaApp/Db/module.template
@@ -85,12 +85,3 @@ record(longin, "$(P)$(R)$(MODULE)RxAcquisitionCount_RBV") {
    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))MODULE_RECEIVED_ACQUISITION_COUNT")
    field(SCAN, "I/O Intr")
 }
-
-record(ai, "$(P)$(R)$(MODULE)Backend_BufferUsed_RBV") {
-   field(DESC, "Backend RDMA buffer usage")
-   field(DTYP, "asynFloat64")
-   field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))MODULE_RDMA_BUFFER")
-   field(SCAN, "I/O Intr")
-   field(PREC, "1")
-   field(EGU, "%")
-}

--- a/pimegaApp/Db/pimega.template
+++ b/pimegaApp/Db/pimega.template
@@ -1434,7 +1434,7 @@ record(ai, "$(P)$(R)Backend_BufferUsed_RBV")
 {
        field(DTYP, "asynFloat64")
        field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))BACK_BUFFER")
-       field(SCAN, ".1 second")
+       field(SCAN, "I/O Intr")
        field(DESC, "Backend buffer used")
        field(PREC, "1")
        field(EGU, "%")

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -244,7 +244,7 @@ void pimegaDetector::acqTask() {
                 (unsigned int)pimega->acquireParam.numCapture) {
               UPDATEIOCSTATUS("Waiting for trigger");
             } else if (autoSave == 1 &&
-                       processedBackendCount < acq_status.savedFrameNum) {
+                       processedBackendCount < acq_status.savedAcquisitionNum) {
               UPDATEIOCSTATUS("Saving images..");
             } else if (indexEnableBool == true) {
               UPDATEIOCSTATUS("Sending frames to Index");
@@ -1036,7 +1036,7 @@ asynStatus pimegaDetector::readInt32(asynUser *pasynUser, epicsInt32 *value) {
 
     setParameter(ADNumImagesCounter, (int)acq_status.noOfAcquisitionsComplete);
     setParameter(PimegaProcessedImageCounter, (int)acq_status.processedImageNum);
-    setParameter(NDFileNumCaptured, (int)acq_status.savedFrameNum);
+    setParameter(NDFileNumCaptured, (int)acq_status.savedAcquisitionNum);
 
     for (int i = 0; i < pimega->max_num_modules; i++) {
       callParamCallbacks(i);

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -195,7 +195,7 @@ void pimegaDetector::acqTask() {
       uint64_t processedBackendCount;
       pss::acquisition::status acq_status = pss::acquisition::get_status(pimega);
 
-      processedBackendCount = acq_status.processedImageNum;
+      processedBackendCount = acq_status.processed_image_num;
       /* For several Acquires with one backend Capture call, the number of
          images sent to backend X is a multiple of the number of images sent to
          the detector Y ( X = K x Y ). So the offset to establish the end of a
@@ -217,7 +217,7 @@ void pimegaDetector::acqTask() {
           /* Acquire and IOC status message management. Acquire still will wait
              for the images to be saved (if necessary) to go to 0 or will wait
              for index to receive the images or both */
-          if (acq_status.done != DONE_ACQ) {
+          if (acq_status.state != DONE_ACQ) {
             UPDATEIOCSTATUS("Not all images received. Waiting");
           } else if (indexEnableBool == true) {
             UPDATEIOCSTATUS("Sending frames to Index");
@@ -240,11 +240,11 @@ void pimegaDetector::acqTask() {
              to that of the Capture and server status message management block
            */
           if (pimega->acquireParam.numCapture != 0) {
-            if (acq_status.processedImageNum <
+            if (acq_status.processed_image_num <
                 (unsigned int)pimega->acquireParam.numCapture) {
               UPDATEIOCSTATUS("Waiting for trigger");
             } else if (autoSave == 1 &&
-                       processedBackendCount < acq_status.savedAcquisitionNum) {
+                       processedBackendCount < acq_status.saved_image_num) {
               UPDATEIOCSTATUS("Saving images..");
             } else if (indexEnableBool == true) {
               UPDATEIOCSTATUS("Sending frames to Index");
@@ -394,7 +394,7 @@ void pimegaDetector::captureTask() {
         backendStatus != 0 permits that the thread executes this snippet the
        last time when the NDFileCapture is set to 0 */
 
-    received_acq = acq_status.noOfAcquisitionsComplete;
+    received_acq = acq_status.acquired_image_num;
 
     this->lock();
     if (pimega->acquireParam.numCapture != 0 && capture) {
@@ -405,9 +405,9 @@ void pimegaDetector::captureTask() {
         UPDATESERVERSTATUS("Aborted");
       } else if (received_acq < (int)pimega->acquireParam.numCapture) {
         UPDATESERVERSTATUS("Waiting for images");
-      } else if (autoSave == 1 && acq_status.done != DONE_ACQ) {
+      } else if (autoSave == 1 && acq_status.state != DONE_ACQ) {
         UPDATESERVERSTATUS("Saving");
-      } else if ((int)acq_status.processedImageNum <
+      } else if ((int)acq_status.processed_image_num <
                  (int)pimega->acquireParam.numCapture) {
         UPDATESERVERSTATUS("Processing images");
       } else {
@@ -980,7 +980,7 @@ asynStatus pimegaDetector::readFloat64(asynUser *pasynUser, epicsFloat64 *value)
 
   if (function == PimegaBackBuffer) {
     pss::acquisition::status acq_status = pss::acquisition::get_status(pimega);
-    *value = acq_status.bufferUsed[0] * 100;
+    *value = acq_status.modules[0].buffer_usage * 100;
   }
 
   else if (function == PimegaDacOutSense) {
@@ -1024,19 +1024,21 @@ asynStatus pimegaDetector::readInt32(asynUser *pasynUser, epicsInt32 *value) {
     pss::acquisition::status acq_status = pss::acquisition::get_status(pimega);
 
     for (int module = 0; module < pimega->max_num_modules; module++) {
+      const auto &mod_status = acq_status.modules[module];
+
       setParameter(PimegaModuleLostFrameCount,
-                   (int)acq_status.lostFrameCnt[module], module);
+                   (int)mod_status.lost_frame_num, module);
       setParameter(PimegaModuleRxFrameCount,
-                   (int)acq_status.noOfFrames[module], module);
+                   (int)mod_status.acquired_frame_num, module);
       setParameter(PimegaModuleAcquisitionCount,
-                   (int)acq_status.noOfAcquisitions[module], module);
+                   (int)mod_status.acquired_image_num, module);
       setParameter(PimegaModuleRdmaBufferUsage,
-                   (double)acq_status.bufferUsed[module] * 100, module);
+                   (double)mod_status.buffer_usage * 100, module);
     }
 
-    setParameter(ADNumImagesCounter, (int)acq_status.noOfAcquisitionsComplete);
-    setParameter(PimegaProcessedImageCounter, (int)acq_status.processedImageNum);
-    setParameter(NDFileNumCaptured, (int)acq_status.savedAcquisitionNum);
+    setParameter(ADNumImagesCounter, (int)acq_status.acquired_image_num);
+    setParameter(PimegaProcessedImageCounter, (int)acq_status.processed_image_num);
+    setParameter(NDFileNumCaptured, (int)acq_status.saved_image_num);
 
     for (int i = 0; i < pimega->max_num_modules; i++) {
       callParamCallbacks(i);
@@ -1562,7 +1564,7 @@ void pimegaDetector::report(FILE *fp, int details) {
 asynStatus pimegaDetector::waitForBackendStatus(int status) {
   while (true) {
     pss::acquisition::status acq_status = pss::acquisition::get_status(pimega);
-    int current_status = acq_status.done;
+    int current_status = acq_status.state;
 
     if (current_status == status)
       break;
@@ -1658,7 +1660,7 @@ asynStatus pimegaDetector::startCaptureBackend(void) {
 
     pss::acquisition::status acq_status = pss::acquisition::get_status(pimega);
 
-    if (acq_status.done == PERMISSION_DENIED) {
+    if (acq_status.state == PERMISSION_DENIED) {
       UPDATESERVERSTATUS("Permission denied to open file");
 
       send_stopAcquire_to_backend(pimega);

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -978,12 +978,7 @@ asynStatus pimegaDetector::readFloat64(asynUser *pasynUser, epicsFloat64 *value)
 
   getParameter(ADAcquire, &acquireRunning);
 
-  if (function == PimegaBackBuffer) {
-    pss::acquisition::status acq_status = pss::acquisition::get_status(pimega);
-    *value = acq_status.modules[0].buffer_usage * 100;
-  }
-
-  else if (function == PimegaDacOutSense) {
+  if (function == PimegaDacOutSense) {
     if (acquireRunning == 1) {
       strncpy(pimega->error, "Stop current acquisition first", sizeof(pimega->error));
       status = asynError;
@@ -1032,13 +1027,12 @@ asynStatus pimegaDetector::readInt32(asynUser *pasynUser, epicsInt32 *value) {
                    (int)mod_status.acquired_frame_num, module);
       setParameter(PimegaModuleAcquisitionCount,
                    (int)mod_status.acquired_image_num, module);
-      setParameter(PimegaModuleRdmaBufferUsage,
-                   (double)mod_status.buffer_usage * 100, module);
     }
 
     setParameter(ADNumImagesCounter, (int)acq_status.acquired_image_num);
     setParameter(PimegaProcessedImageCounter, (int)acq_status.processed_image_num);
     setParameter(NDFileNumCaptured, (int)acq_status.saved_image_num);
+    setParameter(PimegaBackBuffer, (double)acq_status.buffer_usage * 100);
 
     for (int i = 0; i < pimega->max_num_modules; i++) {
       callParamCallbacks(i);
@@ -1396,7 +1390,6 @@ void pimegaDetector::createParameters(void) {
   createParam(pimegaModuleLostFrameCountString, asynParamInt32, &PimegaModuleLostFrameCount);
   createParam(pimegaModuleRxFrameCountString, asynParamInt32, &PimegaModuleRxFrameCount);
   createParam(pimegaModuleAcquisitionCountString, asynParamInt32, &PimegaModuleAcquisitionCount);
-  createParam(pimegaModuleRdmaBufferUsageString, asynParamFloat64, &PimegaModuleRdmaBufferUsage);
   createParam(pimegaBackendStatsString, asynParamInt32, &PimegaBackendStats);
   createParam(pimegaMetadataFieldString, asynParamOctet, &PimegaMetadataField);
   createParam(pimegaMetadataValueString, asynParamOctet, &PimegaMetadataValue);
@@ -1461,7 +1454,6 @@ asynStatus pimegaDetector::setDefaults(void) {
   setParameter(NDFileTemplate, "");
   setParameter(NDFullFileName, "");
   setParameter(NDFileWriteMessage, "");
-  setParameter(PimegaBackBuffer, 0.0);
   setParameter(ADImageMode, ADImageSingle);
   setParameter(PimegaProcessedImageCounter, 0);
 
@@ -1469,13 +1461,13 @@ asynStatus pimegaDetector::setDefaults(void) {
     setParameter(PimegaModuleLostFrameCount, 0, i);
     setParameter(PimegaModuleRxFrameCount, 0, i);
     setParameter(PimegaModuleAcquisitionCount, 0, i);
-    setParameter(PimegaModuleRdmaBufferUsage, 0.0, i);
     setParameter(PimegaModuleTemperatureHighest, 0.0, i);
     setParameter(PimegaModuleMPAvgTSensor, 0.0, i);
   }
 
   setParameter(NDFileNumCaptured, 0);
   setParameter(PimegaFrameProcessMode, 0);
+  setParameter(PimegaBackBuffer, 0.0);
 
   setParameter(PimegaModule, 10);
   setParameter(PimegaMedipixBoard, 2);

--- a/pimegaApp/src/pimegaDetector.h
+++ b/pimegaApp/src/pimegaDetector.h
@@ -174,7 +174,6 @@ typedef enum ioc_trigger_mode_t {
 #define pimegaModuleLostFrameCountString "MODULE_LOST_FRAME_COUNT"
 #define pimegaModuleRxFrameCountString "MODULE_RECEIVED_FRAME_COUNT"
 #define pimegaModuleAcquisitionCountString "MODULE_RECEIVED_ACQUISITION_COUNT"
-#define pimegaModuleRdmaBufferUsageString "MODULE_RDMA_BUFFER"
 #define pimegaBackendStatsString "BACKEND_STATS"
 #define pimegaMetadataFieldString "METADATA_FIELD"
 #define pimegaMetadataValueString "METADATA_VALUE"
@@ -308,7 +307,6 @@ class pimegaDetector : public ADDriver {
   int PimegaModuleLostFrameCount;
   int PimegaModuleRxFrameCount;
   int PimegaModuleAcquisitionCount;
-  int PimegaModuleRdmaBufferUsage;
   int PimegaBackendStats;
   int PimegaMetadataField;
   int PimegaMetadataValue;


### PR DESCRIPTION
There is a recent breaking change in libpimega, which has improved the naming scheme for the acquisition status fields. Use the new names here.

We also explicitly change from the number of frames to the number of images counter in the returned status. This better reflects the information we need to export to the users. The legacy field is no longer part of the reported values for the new API with better names.