### PR TITLE
Don't accept to capture zero images

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,14 @@ ChangeLog](https://common-changelog.org) with minor tweaks, namely the use of
 "Unreleased" header, lack of references for each entry and lack of date on
 released versions.
 
+## Unreleased
+
+### Changed
+
+- Don't accept to capture zero images (Henrique F. Simoes)
+  - Prevent this invalid number of images to be sent to the backend and leave
+    it in an invalid state.
+
 ## 2.6.0
 
 Users interested in changing pixel modes, diagnostic PVs for PIMEGA 450D(S) or

--- a/pimegaApp/Db/pimega.template
+++ b/pimegaApp/Db/pimega.template
@@ -56,7 +56,7 @@ record(ai, "$(P)$(R)TimeRemaining_RBV")
 record(longout, "$(P)$(R)NumCapture")
 {
 	field(DRVH, "2147483647")
-	field(DRVL, "0")	
+	field(DRVL, "1")
 }
 
 

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -560,6 +560,15 @@ asynStatus pimegaDetector::writeInt32(asynUser *pasynUser, epicsInt32 value) {
         strcat(ok_str, "Backend already stopped");
       }
     }
+  } else if (function == NDFileNumCapture) {
+    UPDATEIOCSTATUS("Setting number of images to save");
+    /*
+     * Don't allow to set zero (or a negative number of) images to be captured
+     * by the backend, as it doesn't properly handle this situation and will
+     * fail.
+     */
+    status = value >= 1 ? asynSuccess : asynError;
+    strcat(ok_str, "Number of images to save set");
   } else if (acquireRunning == 1) {
     strncpy(pimega->error, "Stop current acquisition first", sizeof(pimega->error));
     status = asynError;


### PR DESCRIPTION
The backend process takes a value of the number of images to be captured in the current acquisition. However, it will fail with

    Invalid number of acquisitions 0

when it is provided zero images. In some versions, it will get into an invalid condition and spin trying to use a socket in an invalid state; while in more recent ones, it will simply exit with an error. Both of these situations are too harsh for a simple mistake when writing to a NumCapture PV and attempting to acquire. Teach ADPimega that providing zero (or any negative value) is an invalid value for the backend process, and refuse to write this to the parameter list.

Implement this directly to the NDFileNumCapture handling block to avoid a more complex code where dozens of `if` branches are shared by completely different scenarios. This way, it should become easier to later refactor writeInt32 to stop being a hundred-line long method.