### PR TITLE
Refactor configureAlignment usages and implementation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,12 @@ released versions.
   - Prevent this invalid number of images to be sent to the backend and leave
     it in an invalid state.
 
+### Fixed
+
+- Improve error handling when starting an acquisition (Henrique F. Simoes)
+  - When an improbable error occurs when setting the number of images to be
+    collected, correctly report that the acquisition failed.
+
 ## 2.6.0
 
 Users interested in changing pixel modes, diagnostic PVs for PIMEGA 450D(S) or

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -1624,7 +1624,7 @@ asynStatus pimegaDetector::startCaptureBackend(void) {
   /* Create the full filename */
   createFileName(sizeof(fullFileName), fullFileName);
   setParameter(NDFullFileName, fullFileName);
-  rc = (asynStatus)set_file_name_template(pimega, fullFileName);
+  rc = set_file_name_template(pimega, fullFileName);
   if (rc != PIMEGA_SUCCESS) return asynError;
   getParameter(PimegaMedipixMode, &acqMode);
   getParameter(NDAutoSave, &autoSave);
@@ -1642,11 +1642,11 @@ asynStatus pimegaDetector::startCaptureBackend(void) {
 
   configureNumImages(static_cast<ioc_trigger_mode_t>(triggerMode));
 
-  rc = (asynStatus)update_backend_acqArgs(pimega, lfsr, autoSave, BoolAcqResetRDMA,
+  rc = update_backend_acqArgs(pimega, lfsr, autoSave, BoolAcqResetRDMA,
                                           pimega->acquireParam.numCapture, frameProcessMode);
   if (rc != PIMEGA_SUCCESS) return asynError;
 
-  rc = (asynStatus)send_acqArgs_to_backend(pimega);
+  rc = send_acqArgs_to_backend(pimega);
   get_acquire_period(pimega);
   setParameter(ADAcquirePeriod, pimega->acquireParam.acquirePeriod);
   if (rc != PIMEGA_SUCCESS) {

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -1640,7 +1640,7 @@ asynStatus pimegaDetector::startCaptureBackend(void) {
   getParameter(PimegaAcqShmemEnable, &ShmemEnable);
   getParameter(PimegaIndexSendMode, &indexSendMode);
 
-  configureNumImages(triggerMode == IOC_TRIGGER_MODE_ALIGNMENT);
+  configureNumImages(static_cast<ioc_trigger_mode_t>(triggerMode));
 
   rc = (asynStatus)update_backend_acqArgs(pimega, lfsr, autoSave, BoolAcqResetRDMA,
                                           pimega->acquireParam.numCapture, frameProcessMode);
@@ -2267,8 +2267,8 @@ asynStatus pimegaDetector::debug(const std::string &method, const std::string &m
   return asynSuccess;
 }
 
-asynStatus pimegaDetector::configureNumImages(bool alignment_mode) {
-  if (alignment_mode) {
+asynStatus pimegaDetector::configureNumImages(ioc_trigger_mode_t trigger_mode) {
+  if (trigger_mode == IOC_TRIGGER_MODE_ALIGNMENT) {
     const auto max_num_capture = std::numeric_limits<int32_t>::max();
     set_numberExposures(pimega, max_num_capture);
     pimega->acquireParam.numCapture = max_num_capture;

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -2268,12 +2268,12 @@ asynStatus pimegaDetector::debug(const std::string &method, const std::string &m
 }
 
 asynStatus pimegaDetector::configureNumImages(bool alignment_mode) {
-  int numExposuresVar;
-  const auto max_num_capture = std::numeric_limits<int32_t>::max();
   if (alignment_mode) {
+    const auto max_num_capture = std::numeric_limits<int32_t>::max();
     set_numberExposures(pimega, max_num_capture);
     pimega->acquireParam.numCapture = max_num_capture;
   } else {
+    int numExposuresVar;
     getIntegerParam(ADNumExposures, &numExposuresVar);
     set_numberExposures(pimega, numExposuresVar);
     getParameter(NDFileNumCapture, &pimega->acquireParam.numCapture);

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -8,6 +8,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <limits>
+
 #include <lib/zmq_message_broker.hpp>
 
 const NDDataType_t vis_ndarray_dtype = NDUInt32;
@@ -2267,7 +2269,7 @@ asynStatus pimegaDetector::debug(const std::string &method, const std::string &m
 
 asynStatus pimegaDetector::configureNumImages(bool alignment_mode) {
   int numExposuresVar;
-  int max_num_capture = 2147483647;
+  const auto max_num_capture = std::numeric_limits<int32_t>::max();
   if (alignment_mode) {
     set_numberExposures(pimega, max_num_capture);
     pimega->acquireParam.numCapture = max_num_capture;

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -2268,16 +2268,20 @@ asynStatus pimegaDetector::debug(const std::string &method, const std::string &m
 }
 
 asynStatus pimegaDetector::configureNumImages(ioc_trigger_mode_t trigger_mode) {
+  int rc;
+
   if (trigger_mode == IOC_TRIGGER_MODE_ALIGNMENT) {
     const auto max_num_capture = std::numeric_limits<int32_t>::max();
-    set_numberExposures(pimega, max_num_capture);
+    rc = set_numberExposures(pimega, max_num_capture);
     pimega->acquireParam.numCapture = max_num_capture;
   } else {
     int numExposuresVar;
     getIntegerParam(ADNumExposures, &numExposuresVar);
-    set_numberExposures(pimega, numExposuresVar);
+    rc = set_numberExposures(pimega, numExposuresVar);
     getParameter(NDFileNumCapture, &pimega->acquireParam.numCapture);
   }
+
+  return rc == PIMEGA_SUCCESS ? asynSuccess : asynError;
 }
 
 /* Code for iocsh registration */

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -290,7 +290,6 @@ void pimegaDetector::finishAcq(int trigger, int &acquire, int &acquireStatus,
 
   switch (trigger) {
     case IOC_TRIGGER_MODE_ALIGNMENT:
-      configureNumImages(false);
       PIMEGA_PRINT(pimega, TRACE_MASK_FLOW, "%s: Alignment stopped\n", __func__);
       UPDATEIOCSTATUS("Alignment stopped");
       break;

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -1640,7 +1640,9 @@ asynStatus pimegaDetector::startCaptureBackend(void) {
   getParameter(PimegaAcqShmemEnable, &ShmemEnable);
   getParameter(PimegaIndexSendMode, &indexSendMode);
 
-  configureNumImages(static_cast<ioc_trigger_mode_t>(triggerMode));
+  asynStatus status = configureNumImages(static_cast<ioc_trigger_mode_t>(triggerMode));
+  if (status != asynSuccess)
+    return status;
 
   rc = update_backend_acqArgs(pimega, lfsr, autoSave, BoolAcqResetRDMA,
                                           pimega->acquireParam.numCapture, frameProcessMode);

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -290,7 +290,7 @@ void pimegaDetector::finishAcq(int trigger, int &acquire, int &acquireStatus,
 
   switch (trigger) {
     case IOC_TRIGGER_MODE_ALIGNMENT:
-      configureAlignment(false);
+      configureNumImages(false);
       PIMEGA_PRINT(pimega, TRACE_MASK_FLOW, "%s: Alignment stopped\n", __func__);
       UPDATEIOCSTATUS("Alignment stopped");
       break;
@@ -1639,7 +1639,7 @@ asynStatus pimegaDetector::startCaptureBackend(void) {
   getParameter(PimegaAcqShmemEnable, &ShmemEnable);
   getParameter(PimegaIndexSendMode, &indexSendMode);
 
-  configureAlignment(triggerMode == IOC_TRIGGER_MODE_ALIGNMENT);
+  configureNumImages(triggerMode == IOC_TRIGGER_MODE_ALIGNMENT);
 
   rc = (asynStatus)update_backend_acqArgs(pimega, lfsr, autoSave, BoolAcqResetRDMA,
                                           pimega->acquireParam.numCapture, frameProcessMode);
@@ -2266,7 +2266,7 @@ asynStatus pimegaDetector::debug(const std::string &method, const std::string &m
   return asynSuccess;
 }
 
-asynStatus pimegaDetector::configureAlignment(bool alignment_mode) {
+asynStatus pimegaDetector::configureNumImages(bool alignment_mode) {
   int numExposuresVar;
   int max_num_capture = 2147483647;
   if (alignment_mode) {

--- a/pimegaApp/src/pimegaDetector.cpp
+++ b/pimegaApp/src/pimegaDetector.cpp
@@ -4,8 +4,8 @@
  */
 
 #include "pimegaDetector.h"
-#include <bits/stdint-uintn.h>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <lib/zmq_message_broker.hpp>

--- a/pimegaApp/src/pimegaDetector.h
+++ b/pimegaApp/src/pimegaDetector.h
@@ -400,7 +400,7 @@ class pimegaDetector : public ADDriver {
   asynStatus setTempMonitor(int enable);
   asynStatus getTemperatureStatus(void);
   asynStatus getTemperatureHighest(void);
-  asynStatus configureNumImages(bool alignment_mode);
+  asynStatus configureNumImages(ioc_trigger_mode_t trigger_mode);
 };
 
 #define NUM_pimega_PARAMS (&LAST_pimega_PARAM - &FIRST_pimega_PARAM + 1)

--- a/pimegaApp/src/pimegaDetector.h
+++ b/pimegaApp/src/pimegaDetector.h
@@ -400,7 +400,7 @@ class pimegaDetector : public ADDriver {
   asynStatus setTempMonitor(int enable);
   asynStatus getTemperatureStatus(void);
   asynStatus getTemperatureHighest(void);
-  asynStatus configureAlignment(bool alignment_mode);
+  asynStatus configureNumImages(bool alignment_mode);
 };
 
 #define NUM_pimega_PARAMS (&LAST_pimega_PARAM - &FIRST_pimega_PARAM + 1)


### PR DESCRIPTION
This method is used more than simply to configure the alignment mode. It actually handles the number of images to be acquired (number of exposures) and to be captured (by the backend). Refactor it to be better honor this scope.

This also fills a gap where the `set_numberExposures` command would fail, but we would report the configuration as successful.