### PR TITLE
Release version 2.6.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,11 @@ ChangeLog](https://common-changelog.org) with minor tweaks, namely the use of
 "Unreleased" header, lack of references for each entry and lack of date on
 released versions.
 
-## Unreleased
+## 2.6.0
+
+Users interested in changing pixel modes, diagnostic PVs for PIMEGA 450D(S) or
+a better reporting of the current number of acquired images should upgrade to
+this release.
 
 ### Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       args:
         REPONAME: epics/modules/areaDetector/ADPimega
         BUILD_PACKAGES: libczmq-dev libjson-c-dev
-        BUILD_TAR_PACKAGES: http://download.lnls.br/packages/libpimega_2.5.4-4_amd64.tar.gz
+        BUILD_TAR_PACKAGES: http://download.lnls.br/packages/libpimega_2.7.0.0-1_amd64.tar.gz
         RUNTIME_PACKAGES: libxml2 libtiff5 libglib2.0-0 libjson-c5 libczmq4 libgomp1
-        RUNTIME_TAR_PACKAGES: http://download.lnls.br/packages/libpimega_2.5.4-4_amd64.tar.gz
+        RUNTIME_TAR_PACKAGES: http://download.lnls.br/packages/libpimega_2.7.0.0-1_amd64.tar.gz
         RUNDIR: /opt/epics/modules/areaDetector/ADPimega/iocs/pimegaIOC/iocBoot/iocPimega


### PR DESCRIPTION
Although there are breaking changes in the PV layer, don't bump the
major number, as this would conflict with the PSS3 versioning scheme. As
there are relevant new features, bump the minor instead.

Also upgrade the pimega library in the `docker-compose.yml` file, so that the libpimega version is properly pinned.

--

This is depending on #31, so I'm marking this as draft for now. I'd like opinions regarding the version number scheme. I'd find it a reasonable option to move to 4-digits as well, but it doesn't seem strictly required in this case. Let me know if you think differently.