### PR TITLE
Move DisabledSensors_RBV to module template

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,9 @@ released versions.
 - Don't accept to capture zero images (Henrique F. Simoes)
   - Prevent this invalid number of images to be sent to the backend and leave
     it in an invalid state.
+- **Breaking**: Rename disabled sensors PVs (Henrique F. Simoes)
+  - Rename them from `DisabledSensorsM<n>_RBV` to `M<n>:DisabledSensors_RBV`
+    where `<n>` is from 1 up to 4.
 
 ## 2.6.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,10 @@ released versions.
     it in an invalid state.
 - **Breaking**: Rename disabled sensors PVs (Henrique F. Simoes)
   - Rename them from `DisabledSensorsM<n>_RBV` to `M<n>:DisabledSensors_RBV`
-    where `<n>` is from 1 up to 4.
+    where `<n>` is the module number.
+- Export `DisabledSensors_RBV` based on the number of modules (Henrique F.
+  Simoes)
+  - Expose it for each module given the detector model instead of 4 modules.
 
 ## 2.6.0
 

--- a/pimegaApp/Db/module.template
+++ b/pimegaApp/Db/module.template
@@ -31,6 +31,16 @@ record(waveform, "$(P)$(R)$(MODULE)Sensor_Temperature_RBV") {
    field(PREC, "2")
 }
 
+record(waveform, "$(P)$(R)$(MODULE)DisabledSensors_RBV")
+{
+    field(DESC, "Disabled sensors")
+    field(DTYP, "asynInt32ArrayIn")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT)MODULE_DISABLED_SENSORS")
+    field(FTVL, "LONG")
+    field(NELM, "36")
+    field(SCAN, "I/O Intr")
+}
+
 record(ai,"$(P)$(R)$(MODULE)Medipix_AvgTemperature_RBV") {
    field(DESC, "Medipix average temperature")
    field(DTYP, "asynFloat64")

--- a/pimegaApp/Db/pimega.template
+++ b/pimegaApp/Db/pimega.template
@@ -1116,7 +1116,7 @@ record(bo, "$(P)$(R)CheckSensors") {
 	field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))CHECK_SENSORS")
 }
 
-record(waveform, "$(P)$(R)DisabledSensorsM1_RBV")
+record(waveform, "$(P)$(R)M1:DisabledSensors_RBV")
 {
 	field(DESC, "Disabled Sensors Reaback")
     field(DTYP, "asynInt32ArrayIn")
@@ -1126,7 +1126,7 @@ record(waveform, "$(P)$(R)DisabledSensorsM1_RBV")
     field(SCAN, "I/O Intr")
 }
 
-record(waveform, "$(P)$(R)DisabledSensorsM2_RBV")
+record(waveform, "$(P)$(R)M2:DisabledSensors_RBV")
 {
 	field(DESC, "Disabled Sensors Reaback")
     field(DTYP, "asynInt32ArrayIn")
@@ -1136,7 +1136,7 @@ record(waveform, "$(P)$(R)DisabledSensorsM2_RBV")
     field(SCAN, "I/O Intr")
 }
 
-record(waveform, "$(P)$(R)DisabledSensorsM3_RBV")
+record(waveform, "$(P)$(R)M3:DisabledSensors_RBV")
 {
 	field(DESC, "Disabled Sensors Reaback")
     field(DTYP, "asynInt32ArrayIn")
@@ -1146,7 +1146,7 @@ record(waveform, "$(P)$(R)DisabledSensorsM3_RBV")
     field(SCAN, "I/O Intr")
 }
 
-record(waveform, "$(P)$(R)DisabledSensorsM4_RBV")
+record(waveform, "$(P)$(R)M4:DisabledSensors_RBV")
 {
 	field(DESC, "Disabled Sensors Reaback")
     field(DTYP, "asynInt32ArrayIn")

--- a/pimegaApp/Db/pimega.template
+++ b/pimegaApp/Db/pimega.template
@@ -1116,47 +1116,6 @@ record(bo, "$(P)$(R)CheckSensors") {
 	field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))CHECK_SENSORS")
 }
 
-record(waveform, "$(P)$(R)M1:DisabledSensors_RBV")
-{
-	field(DESC, "Disabled Sensors Reaback")
-    field(DTYP, "asynInt32ArrayIn")
-    field(INP,  "@asyn($(PORT),0,$(TIMEOUT)MODULE_DISABLED_SENSORS")
-    field(FTVL, "LONG")
-    field(NELM, "36")
-    field(SCAN, "I/O Intr")
-}
-
-record(waveform, "$(P)$(R)M2:DisabledSensors_RBV")
-{
-	field(DESC, "Disabled Sensors Reaback")
-    field(DTYP, "asynInt32ArrayIn")
-    field(INP,  "@asyn($(PORT),1,$(TIMEOUT)MODULE_DISABLED_SENSORS")
-    field(FTVL, "LONG")
-    field(NELM, "36")
-    field(SCAN, "I/O Intr")
-}
-
-record(waveform, "$(P)$(R)M3:DisabledSensors_RBV")
-{
-	field(DESC, "Disabled Sensors Reaback")
-    field(DTYP, "asynInt32ArrayIn")
-    field(INP,  "@asyn($(PORT),2,$(TIMEOUT)MODULE_DISABLED_SENSORS")
-    field(FTVL, "LONG")
-    field(NELM, "36")
-    field(SCAN, "I/O Intr")
-}
-
-record(waveform, "$(P)$(R)M4:DisabledSensors_RBV")
-{
-	field(DESC, "Disabled Sensors Reaback")
-    field(DTYP, "asynInt32ArrayIn")
-    field(INP,  "@asyn($(PORT),3,$(TIMEOUT)MODULE_DISABLED_SENSORS")
-    field(FTVL, "LONG")
-    field(NELM, "36")
-    field(SCAN, "I/O Intr")
-}
-
-
 record(bi,"$(P)$(R)SendDAC_Done_RBV") {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SEND_DAC_DONE")


### PR DESCRIPTION
These PVs are module-based, so they must belong to the module.template
file, which makes them properly replicated for all the detector modules
by the model substitution files. Move it there.

Fixes: 8e92516e4d5b1a18b96d54ce51629aee426fb14d (Move module-specific records to dedicated template, 2025-02-27)

---

This is a leftover from #24.